### PR TITLE
Make lint workflows ignore generated folder

### DIFF
--- a/.github/workflows/language_lint.yml
+++ b/.github/workflows/language_lint.yml
@@ -3,15 +3,19 @@ on:
   workflow_dispatch: ~
   push:
     paths:
-      - "**.java"
+      - ".github/workflows/**"
+      - "src/main/**.java"
       - "**.json"
+      - "manage_languages.py"
     branches:
       - "stable"
       - "development"
   pull_request:
     paths:
-      - "**.java"
+      - ".github/workflows/**"
+      - "src/main/**.java"
       - "**.json"
+      - "manage_languages.py"
     types:
       - opened
       - synchronize

--- a/.github/workflows/lint_commit.yml
+++ b/.github/workflows/lint_commit.yml
@@ -3,8 +3,12 @@ on:
   workflow_dispatch: ~
   push:
     paths:
-      - "**.java"
+      - ".github/workflows/**"
+      - "src/main/**.java"
       - "**.json"
+      - "build.gradle"
+      - "format_whitespace.py"
+      - "manage_languages.py"
     branches:
       - "development"
 jobs:


### PR DESCRIPTION
But run them on linter and workflow changes

## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My pull request is unique and no other pull requests have been opened for these changes
- [ ] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [ ] I am responsible for any copyright issues with my code if it occurs in the future.